### PR TITLE
Added support for contexts (including for canceling and timing out)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 sudo: false
 go:
-- 1.6
-- 1.7
-- 1.8
+- "1.9"
+- "1.10"
 - tip
 script:
 - ./test

--- a/pool.go
+++ b/pool.go
@@ -1,12 +1,14 @@
 package pool
 
 import (
+	"context"
 	"errors"
-	"github.com/jolestar/go-commons-pool/collections"
-	"github.com/jolestar/go-commons-pool/concurrent"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/jolestar/go-commons-pool/collections"
+	"github.com/jolestar/go-commons-pool/concurrent"
 )
 
 type baseErr struct {
@@ -119,7 +121,19 @@ func (pool *ObjectPool) addIdleObject(p *PooledObject) {
 // By contract, clients must return the borrowed instance
 // using ReturnObject, InvalidateObject
 func (pool *ObjectPool) BorrowObject() (interface{}, error) {
-	return pool.borrowObject(pool.Config.MaxWaitMillis)
+	ctx := context.Background()
+
+	if pool.Config.MaxWaitMillis >= 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(pool.Config.MaxWaitMillis)*time.Millisecond)
+		defer cancel()
+	}
+
+	return pool.BorrowObjectWithContext(ctx)
+}
+
+func (pool *ObjectPool) BorrowObjectWithContext(ctx context.Context) (interface{}, error) {
+	return pool.borrowObject(ctx)
 }
 
 // GetNumIdle return the number of instances currently idle in pool. This may be
@@ -221,7 +235,7 @@ func (pool *ObjectPool) updateStatsReturn(activeTime int64) {
 	//activeTimes.add(activeTime);
 }
 
-func (pool *ObjectPool) borrowObject(borrowMaxWaitMillis int64) (interface{}, error) {
+func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 	if pool.IsClosed() {
 		return nil, NewIllegalStateErr("Pool not open")
 	}
@@ -256,20 +270,11 @@ func (pool *ObjectPool) borrowObject(borrowMaxWaitMillis int64) (interface{}, er
 				}
 			}
 			if p == nil {
-				if borrowMaxWaitMillis < 0 {
-					obj, err := pool.idleObjects.TakeFirst()
-					if err != nil {
-						return nil, err
-					}
-					p, ok = obj.(*PooledObject)
-				} else {
-					obj, err := pool.idleObjects.PollFirstWithTimeout(time.Duration(borrowMaxWaitMillis) * time.Millisecond)
-					if err != nil {
-						return nil, err
-					}
-					p, ok = obj.(*PooledObject)
+				obj, err := pool.idleObjects.PollFirstWithContext(ctx)
+				if err != nil {
+					return nil, err
 				}
-
+				p, ok = obj.(*PooledObject)
 			}
 			if !ok {
 				return nil, NewNoSuchElementErr("Timeout waiting for idle object")

--- a/pool.go
+++ b/pool.go
@@ -132,6 +132,15 @@ func (pool *ObjectPool) BorrowObject() (interface{}, error) {
 	return pool.BorrowObjectWithContext(ctx)
 }
 
+// BorrowObjectWithContext obtains an instance from pool.
+// Instances returned from pool method will have been either newly created
+// with PooledObjectFactory.MakeObject or will be a previously
+// idle object and have been activated with
+// PooledObjectFactory.ActivateObject and then validated with
+// PooledObjectFactory.ValidateObject.
+//
+// By contract, clients must return the borrowed instance
+// using ReturnObject, InvalidateObject
 func (pool *ObjectPool) BorrowObjectWithContext(ctx context.Context) (interface{}, error) {
 	return pool.borrowObject(ctx)
 }
@@ -653,7 +662,6 @@ func (pool *ObjectPool) evict() {
 			}
 		}
 	}
-
 }
 
 func (pool *ObjectPool) ensureMinIdle() {

--- a/pool_abandoned_test.go
+++ b/pool_abandoned_test.go
@@ -1,13 +1,15 @@
 package pool
 
 import (
+	"context"
 	"fmt"
-	"github.com/jolestar/go-commons-pool/concurrent"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jolestar/go-commons-pool/concurrent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type AbandonedTestObject struct {
@@ -344,8 +346,11 @@ func (suit *PoolAbandonedTestSuite) TestWhenExhaustedBlock() {
 
 	suit.NoErrorWithResult(suit.pool.BorrowObject())
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	start := currentTimeMillis()
-	o2 := suit.NoErrorWithResult(suit.pool.borrowObject(5000))
+	o2 := suit.NoErrorWithResult(suit.pool.borrowObject(ctx))
 	end := currentTimeMillis()
 
 	suit.pool.ReturnObject(o2)

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,14 +1,10 @@
 package pool
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/fortytw2/leaktest"
-	"github.com/jolestar/go-commons-pool/collections"
-	"github.com/jolestar/go-commons-pool/concurrent"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"math"
 	"math/rand"
 	"os"
@@ -16,6 +12,12 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/jolestar/go-commons-pool/collections"
+	"github.com/jolestar/go-commons-pool/concurrent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type TestObject struct {
@@ -222,6 +224,8 @@ func (suit *PoolTestSuite) ErrorWithResult(object interface{}, err error) error 
 }
 
 func TestPoolTestSuite(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(PoolTestSuite))
 }
 
@@ -880,8 +884,7 @@ func (suit *PoolTestSuite) TestTimeoutNoLeak() {
 	suit.NoError(err)
 	obj2 := suit.NoErrorWithResult(suit.pool.BorrowObject())
 	err3 := suit.ErrorWithResult(suit.pool.BorrowObject())
-	_, ok := err3.(*NoSuchElementErr)
-	suit.True(ok, "expect NoSuchElementErr but get", reflect.TypeOf(err3))
+	suit.IsType(&NoSuchElementErr{}, err3, err3)
 
 	suit.NoError(suit.pool.ReturnObject(obj2))
 	suit.NoError(suit.pool.ReturnObject(obj))
@@ -1220,14 +1223,16 @@ func (suit *PoolTestSuite) TestEvictionInvalid() {
 	}()
 
 	// Sleep to make sure evictor has started
-	time.Sleep(time.Duration(300) * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 
-	err := suit.ErrorWithResult(suit.pool.borrowObject(1))
-	_, ok := err.(*NoSuchElementErr)
-	suit.True(ok, "expect NoSuchElementErr, but get %v", reflect.TypeOf(ok))
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	err := suit.ErrorWithResult(suit.pool.borrowObject(ctx))
+	suit.IsType(err, &NoSuchElementErr{})
 
 	// Make sure evictor has finished
-	time.Sleep(time.Duration(1000) * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	// Should have an empty pool
 	suit.Equal(0, suit.pool.GetNumIdle(), "Idle count different than expected.")
 	suit.Equal(0, suit.pool.GetNumActive(), "Total count different than expected.")
@@ -1483,8 +1488,7 @@ func (suit *PoolTestSuite) TestWhenExhaustedBlockClosePool() {
 	// Check goroutine was interrupted
 	result := <-ch
 	close(ch)
-	_, ok := result.error.(*collections.InterruptedErr)
-	suit.True(ok, "expect InterruptedErr, but get: %v", reflect.TypeOf(result.error))
+	suit.IsType(&collections.InterruptedErr{}, result.error, result.error.Error())
 }
 
 func waitTestGoroutine(pool *ObjectPool, pause int) chan TestGoroutineResult {


### PR DESCRIPTION
In order to support more modern ways of timing out or otherwise canceling calls to borrow an object from the pool, this PR adds support for passing a context to the new method, `BorrowObjectWithContext`.