### PR TITLE
 More complete context support

### DIFF
--- a/collections/queue.go
+++ b/collections/queue.go
@@ -237,27 +237,27 @@ func (q *LinkedBlockingDeque) OfferLast(e interface{}) bool {
 
 // PutFirst link the provided element as the first in the queue, waiting until there
 // is space to do so if the queue is full.
-func (q *LinkedBlockingDeque) PutFirst(e interface{}) {
+func (q *LinkedBlockingDeque) PutFirst(ctx context.Context, e interface{}) {
 	if e == nil {
 		return
 	}
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	for !q.linkFirst(e) {
-		q.notFull.Wait()
+		q.notFull.Wait(ctx)
 	}
 }
 
 // PutLast Link the provided element as the last in the queue, waiting until there
 // is space to do so if the queue is full.
-func (q *LinkedBlockingDeque) PutLast(e interface{}) {
+func (q *LinkedBlockingDeque) PutLast(ctx context.Context, e interface{}) {
 	if e == nil {
 		return
 	}
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	for !q.linkLast(e) {
-		q.notFull.Wait()
+		q.notFull.Wait(ctx)
 	}
 }
 
@@ -287,7 +287,7 @@ func (q *LinkedBlockingDeque) PollFirstWithContext(ctx context.Context) (interfa
 			return nil, nil
 		default:
 		}
-		interrupt = q.notEmpty.WaitWithContext(ctx)
+		interrupt = q.notEmpty.Wait(ctx)
 	}
 	return x, nil
 }
@@ -328,7 +328,7 @@ func (q *LinkedBlockingDeque) PollLastWithContext(ctx context.Context) (interfac
 			return nil, nil
 		default:
 		}
-		interrupt = q.notEmpty.WaitWithContext(ctx)
+		interrupt = q.notEmpty.Wait(ctx)
 	}
 	return x, nil
 }
@@ -346,7 +346,7 @@ func (q *LinkedBlockingDeque) PollLastWithTimeout(timeout time.Duration) (interf
 // TakeFirst unlink the first element in the queue, waiting until there is an element
 // to unlink if the queue is empty.
 // return NewInterruptedErr if wait condition is interrupted
-func (q *LinkedBlockingDeque) TakeFirst() (interface{}, error) {
+func (q *LinkedBlockingDeque) TakeFirst(ctx context.Context) (interface{}, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	var x interface{}
@@ -355,7 +355,7 @@ func (q *LinkedBlockingDeque) TakeFirst() (interface{}, error) {
 		if interrupt {
 			return nil, NewInterruptedErr()
 		}
-		interrupt = q.notEmpty.Wait()
+		interrupt = q.notEmpty.Wait(ctx)
 	}
 	return x, nil
 }
@@ -363,7 +363,7 @@ func (q *LinkedBlockingDeque) TakeFirst() (interface{}, error) {
 // TakeLast unlink the last element in the queue, waiting until there is an element
 // to unlink if the queue is empty.
 // return NewInterruptedErr if wait condition is interrupted
-func (q *LinkedBlockingDeque) TakeLast() (interface{}, error) {
+func (q *LinkedBlockingDeque) TakeLast(ctx context.Context) (interface{}, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	var x interface{}
@@ -372,7 +372,7 @@ func (q *LinkedBlockingDeque) TakeLast() (interface{}, error) {
 		if interrupt {
 			return nil, NewInterruptedErr()
 		}
-		interrupt = q.notEmpty.Wait()
+		interrupt = q.notEmpty.Wait(ctx)
 	}
 	return x, nil
 }

--- a/concurrent/cond.go
+++ b/concurrent/cond.go
@@ -39,19 +39,6 @@ func (cond *TimeoutCond) WaitWithContext(ctx context.Context) bool {
 	}
 }
 
-// WaitWithTimeout wait for signal return remain wait time, and is interrupted
-func (cond *TimeoutCond) WaitWithTimeout(timeout time.Duration) (time.Duration, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	begin := time.Now()
-	interrupted := cond.WaitWithContext(ctx)
-	elapsed := time.Since(begin)
-	remainingTimeout := timeout - elapsed
-
-	return remainingTimeout, interrupted
-}
-
 func (cond *TimeoutCond) addWaiter() {
 	v := atomic.AddUint64(&cond.hasWaiters, 1)
 	if v == 0 {

--- a/concurrent/cond_test.go
+++ b/concurrent/cond_test.go
@@ -1,6 +1,7 @@
 package concurrent
 
 import (
+	"context"
 	"math"
 	"sync"
 	"testing"
@@ -32,7 +33,7 @@ func (o *LockTestObject) lockAndWait() bool {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	o.t.Log("lockAndWait")
-	return o.cond.Wait()
+	return o.cond.Wait(context.Background())
 }
 
 func (o *LockTestObject) lockAndSignal() {

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	"context"
 	"errors"
 	"math"
 	"sync"
@@ -191,6 +192,11 @@ type ObjectPoolConfig struct {
 	* if this value changed after ObjectPool created, should call ObjectPool.StartEvictor to take effect.
 	 */
 	TimeBetweenEvictionRunsMillis int64
+
+	/**
+	 * The context.Context to use when the evictor runs in the background.
+	 */
+	EvitionContext context.Context
 }
 
 // NewDefaultPoolConfig return a ObjectPoolConfig instance init with default value.
@@ -205,6 +211,7 @@ func NewDefaultPoolConfig() *ObjectPoolConfig {
 		SoftMinEvictableIdleTimeMillis: DefaultSoftMinEvictableIdleTimeMillis,
 		NumTestsPerEvictionRun:         DefaultNumTestsPerEvictionRun,
 		EvictionPolicyName:             DefaultEvictionPolicyName,
+		EvitionContext:                 context.Background(),
 		TestOnCreate:                   DefaultTestOnCreate,
 		TestOnBorrow:                   DefaultTestOnBorrow,
 		TestOnReturn:                   DefaultTestOnReturn,
@@ -231,6 +238,7 @@ type EvictionConfig struct {
 	IdleEvictTime     int64
 	IdleSoftEvictTime int64
 	MinIdle           int
+	Context           context.Context
 }
 
 // EvictionPolicy is a interface support custom EvictionPolicy

--- a/config.go
+++ b/config.go
@@ -20,8 +20,6 @@ const (
 	// TODO
 	// DEFAULT_FAIRNESS = false
 
-	// DefaultMaxWaitMillis is the default value of ObjectPoolConfig.MaxWaitMillis
-	DefaultMaxWaitMillis = int64(-1)
 	// DefaultMinEvictableIdleTimeMillis is the default value of ObjectPoolConfig.MinEvictableIdleTimeMillis
 	DefaultMinEvictableIdleTimeMillis = int64(1000 * 60 * 30)
 	// DefaultSoftMinEvictableIdleTimeMillis is the default value of ObjectPoolConfig.SoftMinEvictableIdleTimeMillis
@@ -138,16 +136,6 @@ type ObjectPoolConfig struct {
 	//Fairness                       bool
 
 	/**
-	 * The maximum amount of time (in milliseconds) the
-	 * ObjectPool.BorrowObject() method should block before return
-	 * a error when the pool is exhausted and
-	 *  BlockWhenExhausted is true. When less than 0, the
-	 * ObjectPool.BorrowObject() method may block indefinitely.
-	 *
-	 */
-	MaxWaitMillis int64
-
-	/**
 	 * The minimum amount of time an object may sit idle in the pool
 	 * before it is eligible for eviction by the idle object evictor (if any -
 	 * see TimeBetweenEvictionRunsMillis . When non-positive,
@@ -206,7 +194,6 @@ func NewDefaultPoolConfig() *ObjectPoolConfig {
 		MaxTotal:                       DefaultMaxTotal,
 		MaxIdle:                        DefaultMaxIdle,
 		MinIdle:                        DefaultMinIdle,
-		MaxWaitMillis:                  DefaultMaxWaitMillis,
 		MinEvictableIdleTimeMillis:     DefaultMinEvictableIdleTimeMillis,
 		SoftMinEvictableIdleTimeMillis: DefaultSoftMinEvictableIdleTimeMillis,
 		NumTestsPerEvictionRun:         DefaultNumTestsPerEvictionRun,

--- a/config_test.go
+++ b/config_test.go
@@ -2,8 +2,9 @@ package pool
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPoolConfig(t *testing.T) {
@@ -26,7 +27,6 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, DefaultLifo, config.Lifo)
 	assert.Equal(t, DefaultMaxIdle, config.MaxIdle)
 	assert.Equal(t, DefaultMaxTotal, config.MaxTotal)
-	assert.Equal(t, DefaultMaxWaitMillis, config.MaxWaitMillis)
 	assert.Equal(t, DefaultMinEvictableIdleTimeMillis, config.MinEvictableIdleTimeMillis)
 	assert.Equal(t, DefaultMinIdle, config.MinIdle)
 	assert.Equal(t, DefaultNumTestsPerEvictionRun, config.NumTestsPerEvictionRun)

--- a/example_test.go
+++ b/example_test.go
@@ -21,7 +21,7 @@ func TestExample(t *testing.T) {
 			func(context.Context) (interface{}, error) {
 				return &MyPoolObject{}, nil
 			}))
-	obj, _ := p.BorrowObject()
+	obj, _ := p.BorrowObject(ctx)
 	p.ReturnObject(ctx, obj)
 }
 
@@ -57,7 +57,7 @@ func TestCustomFactoryExample(t *testing.T) {
 
 	ctx := context.Background()
 	p := NewObjectPoolWithDefaultConfig(ctx, new(MyObjectFactory))
-	obj, _ := p.BorrowObject()
+	obj, _ := p.BorrowObject(ctx)
 	p.ReturnObject(ctx, obj)
 }
 
@@ -71,7 +71,7 @@ func TestStringExample(t *testing.T) {
 			*stringPointer = "hello"
 			return stringPointer, nil
 		}))
-	obj, _ := p.BorrowObject()
+	obj, _ := p.BorrowObject(ctx)
 	fmt.Println(obj)
 	assert.Equal(t, "hello", *obj.(*string))
 	p.ReturnObject(ctx, obj)
@@ -82,7 +82,7 @@ func TestStringExample(t *testing.T) {
 //		func() (interface{}, error) {
 //			return "hello", nil
 //		}))
-//	obj, _ := p.BorrowObject()
+//	obj, _ := p.BorrowObject(ctx)
 //	p.ReturnObject(obj)
 //}
 //
@@ -91,6 +91,6 @@ func TestStringExample(t *testing.T) {
 //		func() (interface{}, error) {
 //			return 1, nil
 //		}))
-//	obj, _ := p.BorrowObject()
+//	obj, _ := p.BorrowObject(ctx)
 //	p.ReturnObject(obj)
 //}

--- a/example_test.go
+++ b/example_test.go
@@ -1,59 +1,72 @@
 package pool
 
 import (
+	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type MyPoolObject struct {
 }
 
 func TestExample(t *testing.T) {
-	p := NewObjectPoolWithDefaultConfig(NewPooledObjectFactorySimple(
-		func() (interface{}, error) {
-			return &MyPoolObject{}, nil
-		}))
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewObjectPoolWithDefaultConfig(
+		ctx,
+		NewPooledObjectFactorySimple(
+			func(context.Context) (interface{}, error) {
+				return &MyPoolObject{}, nil
+			}))
 	obj, _ := p.BorrowObject()
-	p.ReturnObject(obj)
+	p.ReturnObject(ctx, obj)
 }
 
 type MyObjectFactory struct {
 }
 
-func (f *MyObjectFactory) MakeObject() (*PooledObject, error) {
+func (f *MyObjectFactory) MakeObject(ctx context.Context) (*PooledObject, error) {
 	return NewPooledObject(&MyPoolObject{}), nil
 }
 
-func (f *MyObjectFactory) DestroyObject(object *PooledObject) error {
+func (f *MyObjectFactory) DestroyObject(ctx context.Context, object *PooledObject) error {
 	//do destroy
 	return nil
 }
 
-func (f *MyObjectFactory) ValidateObject(object *PooledObject) bool {
+func (f *MyObjectFactory) ValidateObject(ctx context.Context, object *PooledObject) bool {
 	//do validate
 	return true
 }
 
-func (f *MyObjectFactory) ActivateObject(object *PooledObject) error {
+func (f *MyObjectFactory) ActivateObject(ctx context.Context, object *PooledObject) error {
 	//do activate
 	return nil
 }
 
-func (f *MyObjectFactory) PassivateObject(object *PooledObject) error {
+func (f *MyObjectFactory) PassivateObject(ctx context.Context, object *PooledObject) error {
 	//do passivate
 	return nil
 }
 
 func TestCustomFactoryExample(t *testing.T) {
-	p := NewObjectPoolWithDefaultConfig(new(MyObjectFactory))
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewObjectPoolWithDefaultConfig(ctx, new(MyObjectFactory))
 	obj, _ := p.BorrowObject()
-	p.ReturnObject(obj)
+	p.ReturnObject(ctx, obj)
 }
 
 func TestStringExample(t *testing.T) {
-	p := NewObjectPoolWithDefaultConfig(NewPooledObjectFactorySimple(
-		func() (interface{}, error) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewObjectPoolWithDefaultConfig(ctx, NewPooledObjectFactorySimple(
+		func(context.Context) (interface{}, error) {
 			var stringPointer = new(string)
 			*stringPointer = "hello"
 			return stringPointer, nil
@@ -61,7 +74,7 @@ func TestStringExample(t *testing.T) {
 	obj, _ := p.BorrowObject()
 	fmt.Println(obj)
 	assert.Equal(t, "hello", *obj.(*string))
-	p.ReturnObject(obj)
+	p.ReturnObject(ctx, obj)
 }
 
 //func TestStringExampleFail(t *testing.T) {

--- a/factory.go
+++ b/factory.go
@@ -1,6 +1,9 @@
 package pool
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // PooledObjectFactory is factory interface for ObjectPool
 type PooledObjectFactory interface {
@@ -12,12 +15,12 @@ type PooledObjectFactory interface {
 	 * return error if there is a problem creating a new instance,
 	 *    this will be propagated to the code requesting an object.
 	 */
-	MakeObject() (*PooledObject, error)
+	MakeObject(ctx context.Context) (*PooledObject, error)
 
 	/**
 	 * Destroys an instance no longer needed by the pool.
 	 */
-	DestroyObject(object *PooledObject) error
+	DestroyObject(ctx context.Context, object *PooledObject) error
 
 	/**
 	 * Ensures that the instance is safe to be returned by the pool.
@@ -25,7 +28,7 @@ type PooledObjectFactory interface {
 	 * return false if object is not valid and should
 	 *         be dropped from the pool, true otherwise.
 	 */
-	ValidateObject(object *PooledObject) bool
+	ValidateObject(ctx context.Context, object *PooledObject) bool
 
 	/**
 	 * Reinitialize an instance to be returned by the pool.
@@ -33,7 +36,7 @@ type PooledObjectFactory interface {
 	 * return error if there is a problem activating object,
 	 *    this error may be swallowed by the pool.
 	 */
-	ActivateObject(object *PooledObject) error
+	ActivateObject(ctx context.Context, object *PooledObject) error
 
 	/**
 	 * Uninitialize an instance to be returned to the idle object pool.
@@ -41,37 +44,37 @@ type PooledObjectFactory interface {
 	 * return error if there is a problem passivating obj,
 	 *    this exception may be swallowed by the pool.
 	 */
-	PassivateObject(object *PooledObject) error
+	PassivateObject(ctx context.Context, object *PooledObject) error
 }
 
 // DefaultPooledObjectFactory is a default PooledObjectFactory impl, support init by func
 type DefaultPooledObjectFactory struct {
-	make      func() (*PooledObject, error)
-	destroy   func(object *PooledObject) error
-	validate  func(object *PooledObject) bool
-	activate  func(object *PooledObject) error
-	passivate func(object *PooledObject) error
+	make      func(ctx context.Context) (*PooledObject, error)
+	destroy   func(ctx context.Context, object *PooledObject) error
+	validate  func(ctx context.Context, object *PooledObject) bool
+	activate  func(ctx context.Context, object *PooledObject) error
+	passivate func(ctx context.Context, object *PooledObject) error
 }
 
 // NewPooledObjectFactorySimple return a DefaultPooledObjectFactory, only custom MakeObject func
 func NewPooledObjectFactorySimple(
-	create func() (interface{}, error)) PooledObjectFactory {
+	create func(context.Context) (interface{}, error)) PooledObjectFactory {
 	return NewPooledObjectFactory(create, nil, nil, nil, nil)
 }
 
 // NewPooledObjectFactory return a DefaultPooledObjectFactory, init with gaven func.
 func NewPooledObjectFactory(
-	create func() (interface{}, error),
-	destroy func(object *PooledObject) error,
-	validate func(object *PooledObject) bool,
-	activate func(object *PooledObject) error,
-	passivate func(object *PooledObject) error) PooledObjectFactory {
+	create func(context.Context) (interface{}, error),
+	destroy func(ctx context.Context, object *PooledObject) error,
+	validate func(ctx context.Context, object *PooledObject) bool,
+	activate func(ctx context.Context, object *PooledObject) error,
+	passivate func(ctx context.Context, object *PooledObject) error) PooledObjectFactory {
 	if create == nil {
 		panic(errors.New("make function can not be nil"))
 	}
 	return &DefaultPooledObjectFactory{
-		make: func() (*PooledObject, error) {
-			o, err := create()
+		make: func(ctx context.Context) (*PooledObject, error) {
+			o, err := create(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -84,38 +87,38 @@ func NewPooledObjectFactory(
 }
 
 // MakeObject see PooledObjectFactory.MakeObject
-func (f *DefaultPooledObjectFactory) MakeObject() (*PooledObject, error) {
-	return f.make()
+func (f *DefaultPooledObjectFactory) MakeObject(ctx context.Context) (*PooledObject, error) {
+	return f.make(ctx)
 }
 
 // DestroyObject see PooledObjectFactory.DestroyObject
-func (f *DefaultPooledObjectFactory) DestroyObject(object *PooledObject) error {
+func (f *DefaultPooledObjectFactory) DestroyObject(ctx context.Context, object *PooledObject) error {
 	if f.destroy != nil {
-		return f.destroy(object)
+		return f.destroy(ctx, object)
 	}
 	return nil
 }
 
 // ValidateObject see PooledObjectFactory.ValidateObject
-func (f *DefaultPooledObjectFactory) ValidateObject(object *PooledObject) bool {
+func (f *DefaultPooledObjectFactory) ValidateObject(ctx context.Context, object *PooledObject) bool {
 	if f.validate != nil {
-		return f.validate(object)
+		return f.validate(ctx, object)
 	}
 	return true
 }
 
 // ActivateObject see PooledObjectFactory.ActivateObject
-func (f *DefaultPooledObjectFactory) ActivateObject(object *PooledObject) error {
+func (f *DefaultPooledObjectFactory) ActivateObject(ctx context.Context, object *PooledObject) error {
 	if f.activate != nil {
-		return f.activate(object)
+		return f.activate(ctx, object)
 	}
 	return nil
 }
 
 // PassivateObject see PooledObjectFactory.PassivateObject
-func (f *DefaultPooledObjectFactory) PassivateObject(object *PooledObject) error {
+func (f *DefaultPooledObjectFactory) PassivateObject(ctx context.Context, object *PooledObject) error {
 	if f.passivate != nil {
-		return f.passivate(object)
+		return f.passivate(ctx, object)
 	}
 	return nil
 }

--- a/pool.go
+++ b/pool.go
@@ -60,17 +60,17 @@ type ObjectPool struct {
 }
 
 // NewObjectPool return new ObjectPool, init with PooledObjectFactory and ObjectPoolConfig
-func NewObjectPool(factory PooledObjectFactory, config *ObjectPoolConfig) *ObjectPool {
-	return NewObjectPoolWithAbandonedConfig(factory, config, nil)
+func NewObjectPool(ctx context.Context, factory PooledObjectFactory, config *ObjectPoolConfig) *ObjectPool {
+	return NewObjectPoolWithAbandonedConfig(ctx, factory, config, nil)
 }
 
 // NewObjectPoolWithDefaultConfig return new ObjectPool init with PooledObjectFactory and default config
-func NewObjectPoolWithDefaultConfig(factory PooledObjectFactory) *ObjectPool {
-	return NewObjectPool(factory, NewDefaultPoolConfig())
+func NewObjectPoolWithDefaultConfig(ctx context.Context, factory PooledObjectFactory) *ObjectPool {
+	return NewObjectPool(ctx, factory, NewDefaultPoolConfig())
 }
 
 // NewObjectPoolWithAbandonedConfig return new ObjectPool init with PooledObjectFactory, ObjectPoolConfig, and AbandonedConfig
-func NewObjectPoolWithAbandonedConfig(factory PooledObjectFactory, config *ObjectPoolConfig, abandonedConfig *AbandonedConfig) *ObjectPool {
+func NewObjectPoolWithAbandonedConfig(ctx context.Context, factory PooledObjectFactory, config *ObjectPoolConfig, abandonedConfig *AbandonedConfig) *ObjectPool {
 	pool := ObjectPool{factory: factory, Config: config,
 		idleObjects:             collections.NewDeque(math.MaxInt32),
 		allObjects:              collections.NewSyncMap(),
@@ -85,28 +85,28 @@ func NewObjectPoolWithAbandonedConfig(factory PooledObjectFactory, config *Objec
 // AddObject create an object using the PooledObjectFactory factory, passivate it, and then place it in
 // the idle object pool. AddObject is useful for "pre-loading"
 // a pool with idle objects. (Optional operation).
-func (pool *ObjectPool) AddObject() error {
+func (pool *ObjectPool) AddObject(ctx context.Context) error {
 	if pool.IsClosed() {
 		return NewIllegalStateErr("Pool not open")
 	}
 	if pool.factory == nil {
 		return NewIllegalStateErr("Cannot add objects without a factory.")
 	}
-	p, e := pool.create()
+	p, e := pool.create(ctx)
 	if e != nil {
 		return e
 	}
-	e = pool.addIdleObject(p)
+	e = pool.addIdleObject(ctx, p)
 	if e != nil {
-		pool.destroy(p)
+		pool.destroy(ctx, p)
 		return e
 	}
 	return nil
 }
 
-func (pool *ObjectPool) addIdleObject(p *PooledObject) error {
+func (pool *ObjectPool) addIdleObject(ctx context.Context, p *PooledObject) error {
 	if p != nil {
-		err := pool.factory.PassivateObject(p)
+		err := pool.factory.PassivateObject(ctx, p)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func (pool *ObjectPool) GetDestroyedByBorrowValidationCount() int {
 	return int(pool.destroyedByBorrowValidationCount.Get())
 }
 
-func (pool *ObjectPool) removeAbandoned(config *AbandonedConfig) {
+func (pool *ObjectPool) removeAbandoned(ctx context.Context, config *AbandonedConfig) {
 	// Generate a list of abandoned objects to remove
 	now := currentTimeMillis()
 	timeout := now - int64((config.RemoveAbandonedTimeout * 1000))
@@ -203,11 +203,11 @@ func (pool *ObjectPool) removeAbandoned(config *AbandonedConfig) {
 		//if (config.getLogAbandoned()) {
 		//pooledObject.printStackTrace(ac.getLogWriter());
 		//}
-		pool.InvalidateObject(pooledObject.Object)
+		pool.InvalidateObject(ctx, pooledObject.Object)
 	}
 }
 
-func (pool *ObjectPool) create() (*PooledObject, error) {
+func (pool *ObjectPool) create(ctx context.Context) (*PooledObject, error) {
 	localMaxTotal := pool.Config.MaxTotal
 	newCreateCount := pool.createCount.IncrementAndGet()
 	if localMaxTotal > -1 && int(newCreateCount) > localMaxTotal ||
@@ -216,7 +216,7 @@ func (pool *ObjectPool) create() (*PooledObject, error) {
 		return nil, nil
 	}
 
-	p, e := pool.factory.MakeObject()
+	p, e := pool.factory.MakeObject(ctx)
 	if e != nil {
 		pool.createCount.DecrementAndGet()
 		return nil, e
@@ -230,11 +230,11 @@ func (pool *ObjectPool) create() (*PooledObject, error) {
 	return p, nil
 }
 
-func (pool *ObjectPool) destroy(toDestroy *PooledObject) {
-	pool.doDestroy(toDestroy, false)
+func (pool *ObjectPool) destroy(ctx context.Context, toDestroy *PooledObject) {
+	pool.doDestroy(ctx, toDestroy, false)
 }
 
-func (pool *ObjectPool) doDestroy(toDestroy *PooledObject, inLock bool) {
+func (pool *ObjectPool) doDestroy(ctx context.Context, toDestroy *PooledObject, inLock bool) {
 	//golang has not recursive lock, so ...
 	if inLock {
 		toDestroy.invalidate()
@@ -243,7 +243,7 @@ func (pool *ObjectPool) doDestroy(toDestroy *PooledObject, inLock bool) {
 	}
 	pool.idleObjects.RemoveFirstOccurrence(toDestroy)
 	pool.allObjects.Remove(toDestroy.Object)
-	pool.factory.DestroyObject(toDestroy)
+	pool.factory.DestroyObject(ctx, toDestroy)
 	pool.destroyedCount.IncrementAndGet()
 	pool.createCount.DecrementAndGet()
 }
@@ -266,7 +266,7 @@ func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 	if ac != nil && ac.RemoveAbandonedOnBorrow &&
 		(pool.GetNumIdle() < 2) &&
 		(pool.GetNumActive() > pool.Config.MaxTotal-3) {
-		pool.removeAbandoned(ac)
+		pool.removeAbandoned(ctx, ac)
 	}
 
 	var p *PooledObject
@@ -283,7 +283,7 @@ func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 		if blockWhenExhausted {
 			p, ok = pool.idleObjects.PollFirst().(*PooledObject)
 			if !ok {
-				p, e = pool.create()
+				p, e = pool.create(ctx)
 				if e != nil {
 					return nil, e
 				}
@@ -308,7 +308,7 @@ func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 		} else {
 			p, ok = pool.idleObjects.PollFirst().(*PooledObject)
 			if !ok {
-				p, e = pool.create()
+				p, e = pool.create(ctx)
 				if e != nil {
 					return nil, e
 				}
@@ -325,9 +325,9 @@ func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 		}
 
 		if p != nil {
-			e := pool.factory.ActivateObject(p)
+			e := pool.factory.ActivateObject(ctx, p)
 			if e != nil {
-				pool.destroy(p)
+				pool.destroy(ctx, p)
 				p = nil
 				if create {
 					return nil, NewNoSuchElementErr("Unable to activate object")
@@ -335,9 +335,9 @@ func (pool *ObjectPool) borrowObject(ctx context.Context) (interface{}, error) {
 			}
 		}
 		if p != nil && (pool.Config.TestOnBorrow || create && pool.Config.TestOnCreate) {
-			validate := pool.factory.ValidateObject(p)
+			validate := pool.factory.ValidateObject(ctx, p)
 			if !validate {
-				pool.destroy(p)
+				pool.destroy(ctx, p)
 				pool.destroyedByBorrowValidationCount.IncrementAndGet()
 				p = nil
 				if create {
@@ -355,14 +355,14 @@ func (pool *ObjectPool) isAbandonedConfig() bool {
 	return pool.AbandonedConfig != nil
 }
 
-func (pool *ObjectPool) ensureIdle(idleCount int, always bool) {
+func (pool *ObjectPool) ensureIdle(ctx context.Context, idleCount int, always bool) {
 	if idleCount < 1 || pool.IsClosed() || (!always && !pool.idleObjects.HasTakeWaiters()) {
 		return
 	}
 
 	for pool.idleObjects.Size() < idleCount {
 		//just ignore create error
-		p, _ := pool.create()
+		p, _ := pool.create(ctx)
 		if p == nil {
 			// Can't create objects, no reason to think another call to
 			// create will work. Give up.
@@ -378,7 +378,7 @@ func (pool *ObjectPool) ensureIdle(idleCount int, always bool) {
 		// Pool closed while object was being added to idle objects.
 		// Make sure the returned object is destroyed rather than left
 		// in the idle object pool (which would effectively be a leak)
-		pool.Clear()
+		pool.Clear(ctx)
 	}
 }
 
@@ -392,7 +392,7 @@ func (pool *ObjectPool) IsClosed() bool {
 
 // ReturnObject return an instance to the pool. By contract, object
 // must have been obtained using BorrowObject()
-func (pool *ObjectPool) ReturnObject(object interface{}) error {
+func (pool *ObjectPool) ReturnObject(ctx context.Context, object interface{}) error {
 	if object == nil {
 		return errors.New("object is nil")
 	}
@@ -420,20 +420,20 @@ func (pool *ObjectPool) ReturnObject(object interface{}) error {
 	activeTime := p.GetActiveTimeMillis()
 
 	if pool.Config.TestOnReturn {
-		if !pool.factory.ValidateObject(p) {
-			pool.destroy(p)
-			pool.ensureIdle(1, false)
+		if !pool.factory.ValidateObject(ctx, p) {
+			pool.destroy(ctx, p)
+			pool.ensureIdle(ctx, 1, false)
 			pool.updateStatsReturn(activeTime)
 			// swallowException(e);
 			return nil
 		}
 	}
 
-	err := pool.factory.PassivateObject(p)
+	err := pool.factory.PassivateObject(ctx, p)
 	if err != nil {
 		//swallowException(e1);
-		pool.destroy(p)
-		pool.ensureIdle(1, false)
+		pool.destroy(ctx, p)
+		pool.ensureIdle(ctx, 1, false)
 		pool.updateStatsReturn(activeTime)
 		// swallowException(e);
 		return nil
@@ -445,7 +445,7 @@ func (pool *ObjectPool) ReturnObject(object interface{}) error {
 
 	maxIdleSave := pool.Config.MaxIdle
 	if pool.IsClosed() || maxIdleSave > -1 && maxIdleSave <= pool.idleObjects.Size() {
-		pool.destroy(p)
+		pool.destroy(ctx, p)
 	} else {
 		if pool.Config.Lifo {
 			pool.idleObjects.AddFirst(p)
@@ -456,7 +456,7 @@ func (pool *ObjectPool) ReturnObject(object interface{}) error {
 			// Pool closed while object was being added to idle objects.
 			// Make sure the returned object is destroyed rather than left
 			// in the idle object pool (which would effectively be a leak)
-			pool.Clear()
+			pool.Clear(ctx)
 		}
 	}
 	pool.updateStatsReturn(activeTime)
@@ -466,11 +466,11 @@ func (pool *ObjectPool) ReturnObject(object interface{}) error {
 // Clear clears any objects sitting idle in the pool, releasing any associated
 // resources (optional operation). Idle objects cleared must be
 // PooledObjectFactory.DestroyObject(PooledObject) .
-func (pool *ObjectPool) Clear() {
+func (pool *ObjectPool) Clear(ctx context.Context) {
 	p, ok := pool.idleObjects.PollFirst().(*PooledObject)
 
 	for ok {
-		pool.destroy(p)
+		pool.destroy(ctx, p)
 		p, ok = pool.idleObjects.PollFirst().(*PooledObject)
 	}
 }
@@ -480,7 +480,7 @@ func (pool *ObjectPool) Clear() {
 // using BorrowObject.
 // This method should be used when an object that has been borrowed is
 // determined (due to an exception or other problem) to be invalid.
-func (pool *ObjectPool) InvalidateObject(object interface{}) error {
+func (pool *ObjectPool) InvalidateObject(ctx context.Context, object interface{}) error {
 	p, ok := pool.allObjects.Get(object).(*PooledObject)
 	if !ok {
 		if pool.isAbandonedConfig() {
@@ -491,15 +491,15 @@ func (pool *ObjectPool) InvalidateObject(object interface{}) error {
 	}
 	p.lock.Lock()
 	if p.state != StateInvalid {
-		pool.doDestroy(p, true)
+		pool.doDestroy(ctx, p, true)
 	}
 	p.lock.Unlock()
-	pool.ensureIdle(1, false)
+	pool.ensureIdle(ctx, 1, false)
 	return nil
 }
 
 // Close pool, and free any resources associated with it.
-func (pool *ObjectPool) Close() {
+func (pool *ObjectPool) Close(ctx context.Context) {
 	if pool.IsClosed() {
 		return
 	}
@@ -515,7 +515,7 @@ func (pool *ObjectPool) Close() {
 
 	pool.closed = true
 	// This clear removes any idle objects
-	pool.Clear()
+	pool.Clear(ctx)
 
 	// Release any goroutines that were waiting for an object
 	pool.idleObjects.InterruptTakeWaiters()
@@ -547,8 +547,8 @@ func (pool *ObjectPool) startEvictor(delay int64) {
 			for {
 				select {
 				case <-pool.evictor.C:
-					pool.evict()
-					pool.ensureMinIdle()
+					pool.evict(pool.Config.EvitionContext)
+					pool.ensureMinIdle(pool.Config.EvitionContext)
 				case <-pool.evictorStopChan:
 					pool.evictorStopWG.Done()
 					return
@@ -593,11 +593,11 @@ func (pool *ObjectPool) getMinIdle() int {
 	return pool.Config.MinIdle
 }
 
-func (pool *ObjectPool) evict() {
+func (pool *ObjectPool) evict(ctx context.Context) {
 	defer func() {
 		ac := pool.AbandonedConfig
 		if ac != nil && ac.RemoveAbandonedOnMaintenance {
-			pool.removeAbandoned(ac)
+			pool.removeAbandoned(ctx, ac)
 		}
 	}()
 
@@ -610,7 +610,8 @@ func (pool *ObjectPool) evict() {
 	evictionConfig := EvictionConfig{
 		IdleEvictTime:     pool.Config.MinEvictableIdleTimeMillis,
 		IdleSoftEvictTime: pool.Config.SoftMinEvictableIdleTimeMillis,
-		MinIdle:           pool.Config.MinIdle}
+		MinIdle:           pool.Config.MinIdle,
+		Context:           pool.Config.EvitionContext}
 
 	testWhileIdle := pool.Config.TestWhileIdle
 	for i, m := 0, pool.getNumTests(); i < m; i++ {
@@ -645,26 +646,26 @@ func (pool *ObjectPool) evict() {
 		evict := evictionPolicy.Evict(&evictionConfig, underTest, pool.idleObjects.Size())
 
 		if evict {
-			pool.destroy(underTest)
+			pool.destroy(ctx, underTest)
 			pool.destroyedByEvictorCount.IncrementAndGet()
 		} else {
 			active := false
 			if testWhileIdle {
-				err := pool.factory.ActivateObject(underTest)
+				err := pool.factory.ActivateObject(ctx, underTest)
 				if err == nil {
 					active = true
 				} else {
-					pool.destroy(underTest)
+					pool.destroy(ctx, underTest)
 					pool.destroyedByEvictorCount.IncrementAndGet()
 				}
 				if active {
-					if !pool.factory.ValidateObject(underTest) {
-						pool.destroy(underTest)
+					if !pool.factory.ValidateObject(ctx, underTest) {
+						pool.destroy(ctx, underTest)
 						pool.destroyedByEvictorCount.IncrementAndGet()
 					} else {
-						err := pool.factory.PassivateObject(underTest)
+						err := pool.factory.PassivateObject(ctx, underTest)
 						if err != nil {
-							pool.destroy(underTest)
+							pool.destroy(ctx, underTest)
 							pool.destroyedByEvictorCount.IncrementAndGet()
 						}
 					}
@@ -678,22 +679,22 @@ func (pool *ObjectPool) evict() {
 	}
 }
 
-func (pool *ObjectPool) ensureMinIdle() {
-	pool.ensureIdle(pool.getMinIdle(), true)
+func (pool *ObjectPool) ensureMinIdle(ctx context.Context) {
+	pool.ensureIdle(ctx, pool.getMinIdle(), true)
 }
 
 // PreparePool Tries to ensure that {@link #getMinIdle()} idle instances are available
 // in the pool.
-func (pool *ObjectPool) PreparePool() {
+func (pool *ObjectPool) PreparePool(ctx context.Context) {
 	if pool.getMinIdle() < 1 {
 		return
 	}
-	pool.ensureMinIdle()
+	pool.ensureMinIdle(ctx)
 }
 
 // Prefill is util func for pre fill pool object
-func Prefill(pool *ObjectPool, count int) {
+func Prefill(ctx context.Context, pool *ObjectPool, count int) {
 	for i := 0; i < count; i++ {
-		pool.AddObject()
+		pool.AddObject(ctx)
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -132,6 +132,15 @@ func (pool *ObjectPool) BorrowObject() (interface{}, error) {
 	return pool.BorrowObjectWithContext(ctx)
 }
 
+// BorrowObjectWithContext obtains an instance from pool.
+// Instances returned from pool method will have been either newly created
+// with PooledObjectFactory.MakeObject or will be a previously
+// idle object and have been activated with
+// PooledObjectFactory.ActivateObject and then validated with
+// PooledObjectFactory.ValidateObject.
+//
+// By contract, clients must return the borrowed instance
+// using ReturnObject, InvalidateObject
 func (pool *ObjectPool) BorrowObjectWithContext(ctx context.Context) (interface{}, error) {
 	return pool.borrowObject(ctx)
 }
@@ -653,7 +662,6 @@ func (pool *ObjectPool) evict() {
 			}
 		}
 	}
-
 }
 
 func (pool *ObjectPool) ensureMinIdle() {

--- a/pool.go
+++ b/pool.go
@@ -134,28 +134,7 @@ func (pool *ObjectPool) addIdleObject(ctx context.Context, p *PooledObject) erro
 //
 // By contract, clients must return the borrowed instance
 // using ReturnObject, InvalidateObject
-func (pool *ObjectPool) BorrowObject() (interface{}, error) {
-	ctx := context.Background()
-
-	if pool.Config.MaxWaitMillis >= 0 {
-		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(pool.Config.MaxWaitMillis)*time.Millisecond)
-		defer cancel()
-	}
-
-	return pool.BorrowObjectWithContext(ctx)
-}
-
-// BorrowObjectWithContext obtains an instance from pool.
-// Instances returned from pool method will have been either newly created
-// with PooledObjectFactory.MakeObject or will be a previously
-// idle object and have been activated with
-// PooledObjectFactory.ActivateObject and then validated with
-// PooledObjectFactory.ValidateObject.
-//
-// By contract, clients must return the borrowed instance
-// using ReturnObject, InvalidateObject
-func (pool *ObjectPool) BorrowObjectWithContext(ctx context.Context) (interface{}, error) {
+func (pool *ObjectPool) BorrowObject(ctx context.Context) (interface{}, error) {
 	return pool.borrowObject(ctx)
 }
 

--- a/pool_abandoned_test.go
+++ b/pool_abandoned_test.go
@@ -363,9 +363,6 @@ func (suit *PoolAbandonedTestSuite) TestWhenExhaustedBlock() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	start := currentTimeMillis()
 	o2 := suit.NoErrorWithResult(suit.pool.borrowObject(ctx))
 	end := currentTimeMillis()

--- a/pool_perf_test.go
+++ b/pool_perf_test.go
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -13,16 +14,17 @@ type BenchObject struct {
 }
 
 func BenchmarkPoolBorrowReturn(b *testing.B) {
-	pool := NewObjectPoolWithDefaultConfig(NewPooledObjectFactorySimple(func() (interface{}, error) {
+	ctx := context.Background()
+	pool := NewObjectPoolWithDefaultConfig(ctx, NewPooledObjectFactorySimple(func(context.Context) (interface{}, error) {
 		return &BenchObject{Num: rand.Int31()}, nil
 	}))
-	defer pool.Close()
+	defer pool.Close(ctx)
 	for i := 0; i < b.N; i++ {
 		o, err := pool.BorrowObject()
 		if err != nil {
 			b.Fail()
 		}
-		err = pool.ReturnObject(o)
+		err = pool.ReturnObject(ctx, o)
 		if err != nil {
 			b.Fail()
 		}
@@ -30,11 +32,12 @@ func BenchmarkPoolBorrowReturn(b *testing.B) {
 }
 
 func BenchmarkPoolBorrowReturnParallel(b *testing.B) {
-	pool := NewObjectPoolWithDefaultConfig(NewPooledObjectFactorySimple(func() (interface{}, error) {
+	ctx := context.Background()
+	pool := NewObjectPoolWithDefaultConfig(ctx, NewPooledObjectFactorySimple(func(context.Context) (interface{}, error) {
 		return &BenchObject{}, nil
 	}))
 	pool.Config.MaxTotal = 100
-	defer pool.Close()
+	defer pool.Close(ctx)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			o, err := pool.BorrowObject()
@@ -43,7 +46,7 @@ func BenchmarkPoolBorrowReturnParallel(b *testing.B) {
 				fmt.Println(err)
 				b.Fail()
 			}
-			err = pool.ReturnObject(o)
+			err = pool.ReturnObject(ctx, o)
 			//fmt.Println("return:",reflect.ValueOf(o).Pointer())
 			if err != nil {
 				fmt.Println(err)
@@ -61,7 +64,7 @@ func NewSleepingObjectFactory() *SleepingObjectFactory {
 	return &SleepingObjectFactory{counter: concurrent.AtomicInteger(0)}
 }
 
-func (f *SleepingObjectFactory) MakeObject() (*PooledObject, error) {
+func (f *SleepingObjectFactory) MakeObject(context.Context) (*PooledObject, error) {
 	if debugTest {
 		fmt.Println("factory MakeObject", f.counter.Get())
 	}
@@ -69,7 +72,7 @@ func (f *SleepingObjectFactory) MakeObject() (*PooledObject, error) {
 	return NewPooledObject(getNthObject(int(f.counter.Get()))), nil
 }
 
-func (f *SleepingObjectFactory) DestroyObject(object *PooledObject) error {
+func (f *SleepingObjectFactory) DestroyObject(ctx context.Context, object *PooledObject) error {
 	if debugTest {
 		fmt.Println("factory DestroyObject", object)
 	}
@@ -77,7 +80,7 @@ func (f *SleepingObjectFactory) DestroyObject(object *PooledObject) error {
 	return nil
 }
 
-func (f *SleepingObjectFactory) ValidateObject(object *PooledObject) bool {
+func (f *SleepingObjectFactory) ValidateObject(ctx context.Context, object *PooledObject) bool {
 	if debugTest {
 		fmt.Println("factory ValidateObject", object)
 	}
@@ -85,7 +88,7 @@ func (f *SleepingObjectFactory) ValidateObject(object *PooledObject) bool {
 	return true
 }
 
-func (f *SleepingObjectFactory) ActivateObject(object *PooledObject) error {
+func (f *SleepingObjectFactory) ActivateObject(ctx context.Context, object *PooledObject) error {
 	if debugTest {
 		fmt.Println("factory ActivateObject", object)
 		defer fmt.Println("factory ActivateObject end")
@@ -94,7 +97,7 @@ func (f *SleepingObjectFactory) ActivateObject(object *PooledObject) error {
 	return nil
 }
 
-func (f *SleepingObjectFactory) PassivateObject(object *PooledObject) error {
+func (f *SleepingObjectFactory) PassivateObject(ctx context.Context, object *PooledObject) error {
 	if debugTest {
 		fmt.Println("factory PassivateObject", object)
 	}
@@ -110,7 +113,7 @@ type TaskStats struct {
 	nrSamples       int
 }
 
-func runOnce(pool *ObjectPool, taskStats *TaskStats) (int64, int64) {
+func runOnce(ctx context.Context, pool *ObjectPool, taskStats *TaskStats) (int64, int64) {
 	taskStats.waiting++
 	if debugTest {
 		fmt.Println("   waiting: ", taskStats.waiting, "   complete: ", taskStats.complete)
@@ -127,7 +130,7 @@ func runOnce(pool *ObjectPool, taskStats *TaskStats) (int64, int64) {
 	}
 
 	rbegin := currentTimeMillis()
-	pool.ReturnObject(o)
+	pool.ReturnObject(ctx, o)
 	rend := currentTimeMillis()
 	taskStats.complete++
 	borrowTime := bend - bbegin
@@ -135,13 +138,13 @@ func runOnce(pool *ObjectPool, taskStats *TaskStats) (int64, int64) {
 	return borrowTime, returnTime
 }
 
-func prefTask(pool *ObjectPool, nrIterations int) chan TaskStats {
+func prefTask(ctx context.Context, pool *ObjectPool, nrIterations int) chan TaskStats {
 	ch := make(chan TaskStats, 1)
 	go func() {
 		taskStats := TaskStats{}
-		runOnce(pool, &taskStats) // warmup
+		runOnce(ctx, pool, &taskStats) // warmup
 		for i := 0; i < nrIterations; i++ {
-			borrowTime, returnTime := runOnce(pool, &taskStats)
+			borrowTime, returnTime := runOnce(ctx, pool, &taskStats)
 			taskStats.totalBorrowTime += borrowTime
 			taskStats.totalReturnTime += returnTime
 			taskStats.nrSamples++
@@ -157,16 +160,16 @@ func prefTask(pool *ObjectPool, nrIterations int) chan TaskStats {
 	return ch
 }
 
-func perfRun(iterations int, nrThreads int, maxTotal int, maxIdle int) {
+func perfRun(ctx context.Context, iterations int, nrThreads int, maxTotal int, maxIdle int) {
 	factory := NewSleepingObjectFactory()
 
-	pool := NewObjectPoolWithDefaultConfig(factory)
+	pool := NewObjectPoolWithDefaultConfig(ctx, factory)
 	pool.Config.MaxTotal = maxTotal
 	pool.Config.MaxIdle = maxIdle
 	pool.Config.TestOnBorrow = true
 	chs := make([]chan TaskStats, nrThreads)
 	for i := 0; i < nrThreads; i++ {
-		chs[i] = prefTask(pool, iterations)
+		chs[i] = prefTask(ctx, pool, iterations)
 	}
 
 	aggregate := TaskStats{}
@@ -194,20 +197,20 @@ func perfRun(iterations int, nrThreads int, maxTotal int, maxIdle int) {
 		aggregate.totalReturnTime/int64(aggregate.nrSamples))
 }
 
-func perfMain() {
+func perfMain(ctx context.Context) {
 	fmt.Println("Increase threads")
-	perfRun(1, 50, 5, 5)
-	perfRun(1, 100, 5, 5)
-	perfRun(1, 200, 5, 5)
-	perfRun(1, 400, 5, 5)
+	perfRun(ctx, 1, 50, 5, 5)
+	perfRun(ctx, 1, 100, 5, 5)
+	perfRun(ctx, 1, 200, 5, 5)
+	perfRun(ctx, 1, 400, 5, 5)
 
 	fmt.Println("Increase threads & poolsize")
-	perfRun(1, 50, 5, 5)
-	perfRun(1, 100, 10, 10)
-	perfRun(1, 200, 20, 20)
-	perfRun(1, 400, 40, 40)
+	perfRun(ctx, 1, 50, 5, 5)
+	perfRun(ctx, 1, 100, 10, 10)
+	perfRun(ctx, 1, 200, 20, 20)
+	perfRun(ctx, 1, 400, 40, 40)
 
 	fmt.Println("Increase maxIdle")
-	perfRun(1, 400, 40, 5)
-	perfRun(1, 400, 40, 40)
+	perfRun(ctx, 1, 400, 40, 5)
+	perfRun(ctx, 1, 400, 40, 40)
 }

--- a/pool_perf_test.go
+++ b/pool_perf_test.go
@@ -20,7 +20,7 @@ func BenchmarkPoolBorrowReturn(b *testing.B) {
 	}))
 	defer pool.Close(ctx)
 	for i := 0; i < b.N; i++ {
-		o, err := pool.BorrowObject()
+		o, err := pool.BorrowObject(ctx)
 		if err != nil {
 			b.Fail()
 		}
@@ -40,7 +40,7 @@ func BenchmarkPoolBorrowReturnParallel(b *testing.B) {
 	defer pool.Close(ctx)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			o, err := pool.BorrowObject()
+			o, err := pool.BorrowObject(ctx)
 			//fmt.Println("borrow:",reflect.ValueOf(o).Pointer())
 			if err != nil {
 				fmt.Println(err)
@@ -119,7 +119,7 @@ func runOnce(ctx context.Context, pool *ObjectPool, taskStats *TaskStats) (int64
 		fmt.Println("   waiting: ", taskStats.waiting, "   complete: ", taskStats.complete)
 	}
 	bbegin := currentTimeMillis()
-	o, _ := pool.BorrowObject()
+	o, _ := pool.BorrowObject(ctx)
 	bend := currentTimeMillis()
 	taskStats.waiting--
 


### PR DESCRIPTION
Removes `BorrowObjectWithContext` in favor of simple using `BorrowObject` and passing in a context. Timeouts for borrowing an object are based on that context. Once the context is done, borrowing an object is canceled.

Added context to `PooledObjectFactory` methods, and other places.

Breaks backward compatibility.