### PR TITLE
#41 sync/atomic: addUint64 panics on ARM with unaligned pointers

### DIFF
--- a/concurrent/cond.go
+++ b/concurrent/cond.go
@@ -10,9 +10,9 @@ import (
 
 // TimeoutCond is a sync.Cond  improve for support wait timeout.
 type TimeoutCond struct {
+	hasWaiters uint64
 	L          sync.Locker
 	signal     chan int
-	hasWaiters uint64
 }
 
 // NewTimeoutCond return a new TimeoutCond


### PR DESCRIPTION
#41 sync/atomic: addUint64 panics on ARM with unaligned pointers, refer to https://github.com/golang/go/issues/23345